### PR TITLE
refreshInstance to force a fresh instance

### DIFF
--- a/src/SingletonTrait.php
+++ b/src/SingletonTrait.php
@@ -26,6 +26,17 @@ trait SingletonTrait
     }
 
     /**
+     * Abandon existing instance and make a fresh instance
+     * @return instance
+     */
+    public static function refreshInstance()
+    {
+        static::$instance = null;
+
+        return static::getInstance();
+    }
+
+    /**
      * __construct
      *
      * @access public


### PR DESCRIPTION
LTT-4906

Add refreshInstance method to singleton trait to allow dead/stale instances to be cycled in a long running deamon

\Kafka\Broker::refreshInstance();
$producer = new \Kafka\Producer();